### PR TITLE
Hide x86-specific tests behind a cfg attr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,8 @@
 //! Sometimes you may want to use SSE41 even with AVX2 is available
 //!
 //!
-//! ```rust
+#![cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), doc="```rust")]
+#![cfg_attr(not(any(target_arch = "x86", target_arch = "x86_64")), doc="```rust,ignore")]
 //! use simdnoise::*;
 //! use core::arch::x86_64::*;
 //!
@@ -1548,6 +1549,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn consistency_4d() {
         let noise_setting = NoiseBuilder::fbm_4d(10, 10, 10, 10).wrap();
         let scalar_noise = unsafe { scalar::get_4d_scaled_noise(&noise_setting) };
@@ -1563,6 +1565,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn consistency_3d() {
         let noise_setting = NoiseBuilder::fbm_3d(23, 23, 23).wrap();
         let scalar_noise = unsafe { scalar::get_3d_scaled_noise(&noise_setting) };
@@ -1578,6 +1581,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn consistency_2d() {
         let noise_setting = NoiseBuilder::fbm_2d(233, 233).wrap();
         let scalar_noise = unsafe { scalar::get_2d_scaled_noise(&noise_setting) };
@@ -1593,6 +1597,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn consistency_1d() {
         let noise_setting = NoiseBuilder::fbm_1d(1000).wrap();
         let scalar_noise = unsafe { scalar::get_1d_scaled_noise(&noise_setting) };
@@ -1608,6 +1613,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn cell_consistency_2d() {
         let noise_setting = NoiseBuilder::cellular_2d(100, 100).wrap();
         let scalar = unsafe { scalar::get_2d_scaled_noise(&noise_setting) };
@@ -1620,7 +1626,9 @@ mod tests {
             assert_delta!(sse41[i], avx2[i], 0.1);
         }
     }
+
     #[test]
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn cell_consistency_3d() {
         let noise_setting = NoiseBuilder::cellular2_3d(32, 32, 32).wrap();
         let scalar = unsafe { scalar::get_3d_scaled_noise(&noise_setting) };


### PR DESCRIPTION
Without this `cargo test` doesn't compile on M1 Mac.