### PR TITLE
Verpeteren/repair GitHub workflow after issue34

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,4 +35,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --all --check

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -5,34 +5,24 @@ const WIDTH: usize = 1920;
 const HEIGHT: usize = 1080;
 
 fn main() {
-
-    
     // Get a block of 3d ridge noise, custom settings, 32x32x32 unscaled
-    let noise = simdnoise::NoiseBuilder::ridge_3d_offset(
-        1200.0,
-        1920,
-        200.0,
-        1080,        
-        1.0,
-        1,        
-    )    
-    .with_freq(1.2)    
-    .with_octaves(8)
-    .generate_scaled(0.0, 255.0);
+    let noise = simdnoise::NoiseBuilder::ridge_3d_offset(1200.0, 1920, 200.0, 1080, 1.0, 1)
+        .with_freq(1.2)
+        .with_octaves(8)
+        .generate_scaled(0.0, 255.0);
 
     /*
-    let noise = simdnoise::NoiseBuilder::ridge_2d_offset(
-        1200.0,
-        1920,
-        200.0,
-        1080,        
-    )    
-    .with_freq(1.2)    
-    .with_octaves(8)
-    .generate_scaled(0.0, 255.0);
-*/
-    let buffer : Vec<u32> = noise.iter().map(|x|  *x as u32).collect();
-    
+        let noise = simdnoise::NoiseBuilder::ridge_2d_offset(
+            1200.0,
+            1920,
+            200.0,
+            1080,
+        )
+        .with_freq(1.2)
+        .with_octaves(8)
+        .generate_scaled(0.0, 255.0);
+    */
+    let buffer: Vec<u32> = noise.iter().map(|x| *x as u32).collect();
 
     let mut window = Window::new(
         "Test - ESC to exit",
@@ -48,14 +38,11 @@ fn main() {
     window.limit_update_rate(Some(std::time::Duration::from_micros(16600)));
 
     while window.is_open() && !window.is_key_down(Key::Escape) {
-
-      /*  for i in buffer.iter_mut() {
+        /*  for i in buffer.iter_mut() {
             *i = 128; // write something more funny here!
         }*/
 
         // We unwrap here as we want this code to exit if it fails. Real applications may want to handle this in a different way
-        window
-            .update_with_buffer(&buffer, WIDTH, HEIGHT)
-            .unwrap();
+        window.update_with_buffer(&buffer, WIDTH, HEIGHT).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,11 @@
 //! Sometimes you may want to use SSE41 even with AVX2 is available
 //!
 //!
-#![cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), doc="```rust")]
-#![cfg_attr(not(any(target_arch = "x86", target_arch = "x86_64")), doc="```rust,ignore")]
+#![cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), doc = "```rust")]
+#![cfg_attr(
+    not(any(target_arch = "x86", target_arch = "x86_64")),
+    doc = "```rust,ignore"
+)]
 //! use simdnoise::*;
 //! use core::arch::x86_64::*;
 //!


### PR DESCRIPTION
@kornelski [issue](https://github.com/verpeteren/rust-simd-noise/pull/34) was merged, but the github workflow failed because the command line arguments for rustfmt failed.
This PR fixes it. As a sideeffect the example file was reformatted too.