### PR TITLE
Scale octave noise between -1 and 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ categories = ["game-engines", "multimedia::images"]
 edition = "2018"
 
 [dependencies]
-#simdeez = "1.0.8"
-simdeez = {path = "../simdeez"}
+simdeez = "1.0.8"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/src/noise/fbm_32.rs
+++ b/src/noise/fbm_32.rs
@@ -11,14 +11,17 @@ pub unsafe fn fbm_1d<S: Simd>(
     seed: i32,
 ) -> S::Vf32 {
     let mut amp = S::set1_ps(1.0);
+    let mut scale = amp;
     let mut result = simplex_1d::<S>(x, seed);
 
     for _ in 1..octaves {
         x = S::mul_ps(x, lacunarity);
         amp = S::mul_ps(amp, gain);
+        scale = S::add_ps(scale, amp);
         result = S::add_ps(result, simplex_1d::<S>(x, seed));
     }
 
+    result = S::div_ps(result, scale);
     result
 }
 
@@ -31,16 +34,19 @@ pub unsafe fn fbm_2d<S: Simd>(
     octaves: u8,
     seed: i32,
 ) -> S::Vf32 {
-    let mut result = simplex_2d::<S>(x, y, seed);
     let mut amp = S::set1_ps(1.0);
+    let mut scale = amp;
+    let mut result = simplex_2d::<S>(x, y, seed);
 
     for _ in 1..octaves {
         x = S::mul_ps(x, lac);
         y = S::mul_ps(y, lac);
         amp = S::mul_ps(amp, gain);
+        scale = S::add_ps(scale, amp);
         result = S::add_ps(S::mul_ps(simplex_2d::<S>(x, y, seed), amp), result);
     }
 
+    result = S::div_ps(result, scale);
     result
 }
 
@@ -54,17 +60,20 @@ pub unsafe fn fbm_3d<S: Simd>(
     octaves: u8,
     seed: i32,
 ) -> S::Vf32 {
-    let mut result = simplex_3d::<S>(x, y, z, seed);
     let mut amp = S::set1_ps(1.0);
+    let mut scale = amp;
+    let mut result = simplex_3d::<S>(x, y, z, seed);
 
     for _ in 1..octaves {
         x = S::mul_ps(x, lac);
         y = S::mul_ps(y, lac);
         z = S::mul_ps(z, lac);
         amp = S::mul_ps(amp, gain);
+        scale = S::add_ps(scale, amp);
         result = S::add_ps(S::mul_ps(simplex_3d::<S>(x, y, z, seed), amp), result);
     }
 
+    result = S::div_ps(result, scale);
     result
 }
 
@@ -79,8 +88,9 @@ pub unsafe fn fbm_4d<S: Simd>(
     octaves: u8,
     seed: i32,
 ) -> S::Vf32 {
-    let mut result = simplex_4d::<S>(x, y, z, w, seed);
     let mut amp = S::set1_ps(1.0);
+    let mut scale = amp;
+    let mut result = simplex_4d::<S>(x, y, z, w, seed);
 
     for _ in 1..octaves {
         x = S::mul_ps(x, lac);
@@ -88,8 +98,10 @@ pub unsafe fn fbm_4d<S: Simd>(
         z = S::mul_ps(z, lac);
         w = S::mul_ps(w, lac);
         amp = S::mul_ps(amp, gain);
+        scale = S::add_ps(scale, amp);
         result = S::add_ps(result, S::mul_ps(simplex_4d::<S>(x, y, z, w, seed), amp));
     }
 
+    result = S::div_ps(result, scale);
     result
 }

--- a/src/noise/fbm_64.rs
+++ b/src/noise/fbm_64.rs
@@ -11,14 +11,17 @@ pub unsafe fn fbm_1d<S: Simd>(
     seed: i64,
 ) -> S::Vf64 {
     let mut amp = S::set1_pd(1.0);
+    let mut scale = amp;
     let mut result = simplex_1d::<S>(x, seed);
 
     for _ in 1..octaves {
         x = S::mul_pd(x, lacunarity);
         amp = S::mul_pd(amp, gain);
+        scale = S::add_pd(scale, amp);
         result = S::add_pd(result, simplex_1d::<S>(x, seed));
     }
 
+    result = S::div_pd(result, scale);
     result
 }
 
@@ -31,16 +34,19 @@ pub unsafe fn fbm_2d<S: Simd>(
     octaves: u8,
     seed: i64,
 ) -> S::Vf64 {
-    let mut result = simplex_2d::<S>(x, y, seed);
     let mut amp = S::set1_pd(1.0);
+    let mut scale = amp;
+    let mut result = simplex_2d::<S>(x, y, seed);
 
     for _ in 1..octaves {
         x = S::mul_pd(x, lac);
         y = S::mul_pd(y, lac);
         amp = S::mul_pd(amp, gain);
+        scale = S::add_pd(scale, amp);
         result = S::add_pd(S::mul_pd(simplex_2d::<S>(x, y, seed), amp), result);
     }
 
+    result = S::div_pd(result, scale);
     result
 }
 
@@ -54,15 +60,20 @@ pub unsafe fn fbm_3d<S: Simd>(
     octaves: u8,
     seed: i64,
 ) -> S::Vf64 {
-    let mut result = simplex_3d::<S>(x, y, z, seed);
     let mut amp = S::set1_pd(1.0);
+    let mut scale = amp;
+    let mut result = simplex_3d::<S>(x, y, z, seed);
+
     for _ in 1..octaves {
         x = S::mul_pd(x, lac);
         y = S::mul_pd(y, lac);
         z = S::mul_pd(z, lac);
         amp = S::mul_pd(amp, gain);
+        scale = S::add_pd(scale, amp);
         result = S::add_pd(S::mul_pd(simplex_3d::<S>(x, y, z, seed), amp), result);
     }
+
+    result = S::div_pd(result, scale);
     result
 }
 
@@ -77,8 +88,9 @@ pub unsafe fn fbm_4d<S: Simd>(
     octaves: u8,
     seed: i64,
 ) -> S::Vf64 {
-    let mut result = simplex_4d::<S>(x, y, z, w, seed);
     let mut amp = S::set1_pd(1.0);
+    let mut scale = amp;
+    let mut result = simplex_4d::<S>(x, y, z, w, seed);
 
     for _ in 1..octaves {
         x = S::mul_pd(x, lac);
@@ -86,8 +98,10 @@ pub unsafe fn fbm_4d<S: Simd>(
         z = S::mul_pd(z, lac);
         w = S::mul_pd(w, lac);
         amp = S::mul_pd(amp, gain);
+        scale = S::add_pd(scale, amp);
         result = S::add_pd(result, S::mul_pd(simplex_4d::<S>(x, y, z, w, seed), amp));
     }
 
+    result = S::div_pd(result, scale);
     result
 }

--- a/src/noise/hash3d_64.rs
+++ b/src/noise/hash3d_64.rs
@@ -33,6 +33,7 @@ pub unsafe fn hash3d<S: Simd>(seed: i64, i: S::Vi64, j: S::Vi64, k: S::Vi64) -> 
     // The codeblock below is just the 64 bit SIMD instructions with the 32 bit magic numbers.
     // I don't know what values the Hash3d fields should hold or what magic number are needed for the bit shifts.
     unimplemented!();
+    /*
     let mut hash = S::xor_epi64(i, S::set1_epi64(seed));
     hash = S::xor_epi64(j, hash);
     hash = S::xor_epi64(k, hash);
@@ -49,4 +50,5 @@ pub unsafe fn hash3d<S: Simd>(seed: i64, i: S::Vi64, j: S::Vi64, k: S::Vi64) -> 
         S::castepi64_pd(S::slli_epi64(hash, 31)),
         S::castepi64_pd(S::slli_epi64(S::and_epi64(hash, S::set1_epi64(2)), 30)),
     )
+    */
 }

--- a/src/noise/simplex_32.rs
+++ b/src/noise/simplex_32.rs
@@ -221,7 +221,7 @@ pub unsafe fn simplex_2d_deriv<S: Simd>(
     let n2 = t42 * g2;
 
     // Scaling factor found by numerical approximation
-    let scale = S::set1_ps(45.26450774985561631259);
+    let scale = S::set1_ps(45.232012178628814);
     let value = S::add_ps(n0, S::add_ps(n1, n2)) * scale;
     let derivative = {
         let temp0 = t20 * t0 * g0;

--- a/src/noise/simplex_64.rs
+++ b/src/noise/simplex_64.rs
@@ -189,7 +189,7 @@ pub unsafe fn simplex_2d_deriv<S: Simd>(
     let n2 = t42 * g2;
 
     // Scaling factor found by numerical approximation
-    let scale = S::set1_pd(45.26450774985561631259);
+    let scale = S::set1_pd(45.232012178628814);
     let value = S::add_pd(n0, S::add_pd(n1, n2)) * scale;
     let derivative = {
         let temp0 = t20 * t0 * g0;


### PR DESCRIPTION
Hello, this aims to solve #39 and #23. I put down the idea just for fbm, but I wanted to ask if maybe you wanted to do it differently.
* For -1..1 scaling the scaling factor can be precomputed. It can be stored with the settings.
* Remove 'generate_scaled' in favor of a 'with_scale' method.

I think this would remove the need to have different functions for scaled and unscaled noise. All noise is scaled, but the scale function(s) would only be run if the user has defined a scale, or if the noise type can be scaled to -1..1. 

