### PR TITLE
Fix fbm_4d/fbm_4d_offset only using 3 dimensions

### DIFF
--- a/src/noise_builder.rs
+++ b/src/noise_builder.rs
@@ -156,7 +156,7 @@ impl NoiseBuilder {
     }
 
     pub fn fbm_4d(width: usize, height: usize, depth: usize, time: usize) -> FbmSettings {
-        let mut dim = NoiseDimensions::default(3);
+        let mut dim = NoiseDimensions::default(4);
         dim.width = width;
         dim.height = height;
         dim.depth = depth;
@@ -174,7 +174,7 @@ impl NoiseBuilder {
         w_offset: f32,
         time: usize,
     ) -> FbmSettings {
-        let mut dim = NoiseDimensions::default(3);
+        let mut dim = NoiseDimensions::default(4);
         dim.width = width;
         dim.height = height;
         dim.depth = depth;


### PR DESCRIPTION
Fixes the 4th dimension of `NoiseBuilder::fbm_4d`/`NoiseBuilder::fbm_4d_offset ` not working due to misconfiguring the NoiseDimensions.
(the other 4d functions in NoiseBuilder already have this)